### PR TITLE
(osmarcf) invalid SVN repository. Google has changed it to a GitHub one.

### DIFF
--- a/GoogleMaps - Cluster/markerclusterer.js
+++ b/GoogleMaps - Cluster/markerclusterer.js
@@ -187,7 +187,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
  * @private
  */
 MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ =
-    'http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/' +
+    'https://github.com/googlemaps/js-marker-clusterer/tree/gh-pages/' +
     'images/m';
 
 


### PR DESCRIPTION
The URL path is outdated. Google is not using that SVN address anymore. The maps are now in a GitHub repository. This pull request only updates the URL to the GitHub repository.
